### PR TITLE
Add VRCFT OSC support for gaze data source

### DIFF
--- a/openxr-api-layer/layer.cpp
+++ b/openxr-api-layer/layer.cpp
@@ -246,6 +246,8 @@ namespace openxr_api_layer {
                         if (!m_forceNoEyeTracking) {
                             if (m_debugSimulateTracking) {
                                 m_trackerType = Tracker::SimulatedTracking;
+                            } else if (m_oscTrackingEnabled) {
+                                m_trackerType = Tracker::OSCTracking;
                             } else if (eyeGazeInteractionProperties.supportsEyeGazeInteraction) {
                                 // Prefer the eye gaze interaction extension over the social eye tracking extension.
                                 m_trackerType = Tracker::EyeGazeInteraction;
@@ -683,6 +685,10 @@ namespace openxr_api_layer {
                         case Tracker::EyeGazeInteraction:
                             initializeEyeGazeInteraction(*session);
                             break;
+
+                        case Tracker::OSCTracking:
+                            initializeOSCTracking(*session);
+                            break;
                         }
 
                         XrReferenceSpaceCreateInfo spaceCreateInfo{XR_TYPE_REFERENCE_SPACE_CREATE_INFO};
@@ -744,6 +750,11 @@ namespace openxr_api_layer {
 
                     m_gazeSpaces.clear();
                     m_swapchains.clear();
+
+                    if (m_oscClient) {
+                        m_oscClient->Shutdown();
+                        m_oscClient.reset();
+                    }
 
                     m_session = XR_NULL_HANDLE;
                 }
@@ -2075,6 +2086,21 @@ namespace openxr_api_layer {
                               TLXArg(m_eyeSpace, "ActionSpace"));
         }
 
+        void initializeOSCTracking(XrSession session) {
+            m_oscClient = std::make_unique<OSCClient>(m_oscAddress.c_str(), m_oscPort);
+            m_oscClient->SetEyeCurveExponents(m_oscEyeCurveExponentUp, m_oscEyeCurveExponentDown, m_oscEyeCurveExponentLeft, m_oscEyeCurveExponentRight);
+            if (m_oscClient->Initialize()) {
+                Log(fmt::format("OSC tracking initialized on {}:{}\n", m_oscAddress, m_oscPort));
+                TraceLoggingWrite(g_traceProvider,
+                                  "OSCTracking",
+                                  TLArg(m_oscAddress.c_str(), "Address"),
+                                  TLArg(m_oscPort, "Port"));
+            } else {
+                Log("Warning: Failed to initialize OSC tracking\n");
+                m_oscClient.reset();
+            }
+        }
+
         bool getSimulatedTracking(XrTime time, bool getStateOnly, XrVector3f& unitVector) {
             // Use the mouse to simulate eye tracking.
             if (!getStateOnly) {
@@ -2166,6 +2192,26 @@ namespace openxr_api_layer {
             return true;
         }
 
+        bool getOSCTracking(XrTime time, bool getStateOnly, XrVector3f& unitVector) {
+            if (!m_oscClient || !m_oscClient->IsConnected()) {
+                return false;
+            }
+
+            if (!m_oscClient->HasValidGaze()) {
+                return false;
+            }
+
+            if (m_oscClient->IsDataStale(m_oscTimeoutMs)) {
+                return false;
+            }
+
+            if (!getStateOnly) {
+                unitVector = m_oscClient->GetGazeVector();
+            }
+
+            return true;
+        }
+
         bool getEyeGaze(XrTime time, bool getStateOnly, XrVector3f& unitVector) {
             // Clear the cache.
             const auto now = std::chrono::steady_clock::now();
@@ -2177,6 +2223,10 @@ namespace openxr_api_layer {
             switch (m_trackerType) {
             case Tracker::SimulatedTracking:
                 result = getSimulatedTracking(time, getStateOnly, unitVector);
+                break;
+
+            case Tracker::OSCTracking:
+                result = getOSCTracking(time, getStateOnly, unitVector);
                 break;
 
             case Tracker::EyeTrackerFB:
@@ -3024,6 +3074,30 @@ namespace openxr_api_layer {
                     } else if (name == "debug_keys") {
                         m_debugKeys = std::stoi(value);
                         parsed = true;
+                    } else if (name == "osc_tracking_enabled") {
+                        m_oscTrackingEnabled = std::stoi(value) != 0;
+                        parsed = true;
+                    } else if (name == "osc_address") {
+                        m_oscAddress = value;
+                        parsed = true;
+                    } else if (name == "osc_port") {
+                        m_oscPort = std::stoi(value);
+                        parsed = true;
+                    } else if (name == "osc_timeout_ms") {
+                        m_oscTimeoutMs = std::stoull(value);
+                        parsed = true;
+                    } else if (name == "osc_eye_curve_exponent_up") {
+                        m_oscEyeCurveExponentUp = std::stof(value);
+                        parsed = true;
+                    } else if (name == "osc_eye_curve_exponent_down") {
+                        m_oscEyeCurveExponentDown = std::stof(value);
+                        parsed = true;
+                    } else if (name == "osc_eye_curve_exponent_left") {
+                        m_oscEyeCurveExponentLeft = std::stof(value);
+                        parsed = true;
+                    } else if (name == "osc_eye_curve_exponent_right") {
+                        m_oscEyeCurveExponentRight = std::stof(value);
+                        parsed = true;
                     } else {
                         Log("L%u: Unrecognized option\n", lineNumber);
                     }
@@ -3052,6 +3126,7 @@ namespace openxr_api_layer {
         enum Tracker {
             None = 0,
             SimulatedTracking,
+            OSCTracking,
             EyeTrackerFB,
             EyeGazeInteraction,
         };
@@ -3162,6 +3237,17 @@ namespace openxr_api_layer {
         bool m_debugEyeGaze{false};
         bool m_debugSimulateTracking{false};
         bool m_debugKeys{false};
+
+        // OSC tracking configuration.
+        bool m_oscTrackingEnabled{false};
+        std::string m_oscAddress{"127.0.0.1"};
+        int m_oscPort{9000};
+        uint64_t m_oscTimeoutMs{500};
+        float m_oscEyeCurveExponentUp{1.0f};
+        float m_oscEyeCurveExponentDown{1.0f};
+        float m_oscEyeCurveExponentLeft{1.0f};
+        float m_oscEyeCurveExponentRight{1.0f};
+        std::unique_ptr<OSCClient> m_oscClient{nullptr};
 
         std::shared_ptr<general::ITimer> m_appFrameCpuTimer;
         std::shared_ptr<general::ITimer> m_appRenderCpuTimer;

--- a/openxr-api-layer/openxr-api-layer.vcxproj
+++ b/openxr-api-layer/openxr-api-layer.vcxproj
@@ -113,7 +113,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
@@ -178,7 +178,7 @@ $(SolutionDir)\scripts\sed.exe -i "s/VALUE \"ProductVersion\", \".*\"$/VALUE \"P
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
@@ -247,7 +247,7 @@ $(SolutionDir)\scripts\sed.exe -i "s/VALUE \"ProductVersion\", \".*\"$/VALUE \"P
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
@@ -316,7 +316,7 @@ $(SolutionDir)\scripts\sed.exe -i "s/VALUE \"ProductVersion\", \".*\"$/VALUE \"P
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
@@ -377,6 +377,7 @@ $(SolutionDir)\scripts\sed.exe -i "s/VALUE \"ProductVersion\", \".*\"$/VALUE \"P
     <ClInclude Include="utils\general.h" />
     <ClInclude Include="utils\graphics.h" />
     <ClInclude Include="utils\inputs.h" />
+    <ClInclude Include="utils\osc_client.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\external\fmt\src\format.cc">
@@ -401,6 +402,7 @@ $(SolutionDir)\scripts\sed.exe -i "s/VALUE \"ProductVersion\", \".*\"$/VALUE \"P
     <ClCompile Include="utils\d3d12.cpp" />
     <ClCompile Include="utils\general.cpp" />
     <ClCompile Include="utils\input.cpp" />
+    <ClCompile Include="utils\osc_client.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\settings.cfg">

--- a/openxr-api-layer/openxr-api-layer.vcxproj.filters
+++ b/openxr-api-layer/openxr-api-layer.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="utils\osc_client.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -93,6 +96,9 @@
     </ClCompile>
     <ClCompile Include="..\external\fmt\src\format.cc">
       <Filter>fmt</Filter>
+    </ClCompile>
+    <ClCompile Include="utils\osc_client.cpp">
+      <Filter>Utilities</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/openxr-api-layer/pch.h
+++ b/openxr-api-layer/pch.h
@@ -54,6 +54,8 @@ using namespace std::chrono_literals;
 // Windows header files.
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #include <unknwn.h>
 #include <wrl.h>
@@ -99,3 +101,4 @@ using Microsoft::WRL::ComPtr;
 #endif
 
 #include <utils/inputs.h>
+#include <utils/osc_client.h>

--- a/openxr-api-layer/utils/osc_client.cpp
+++ b/openxr-api-layer/utils/osc_client.cpp
@@ -1,0 +1,350 @@
+// MIT License
+//
+// Copyright(c) 2022-2023 Matthieu Bucchianeri
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this softwareand associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and /or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright noticeand this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "pch.h"
+#include "osc_client.h"
+#include "framework/log.h"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#pragma comment(lib, "ws2_32.lib")
+
+#include <cstring>
+#include <cstdlib>
+
+OSCClient::OSCClient(const char* address, int port) : m_address(address), m_port(port), m_socket(nullptr) {
+}
+
+OSCClient::~OSCClient() {
+    Shutdown();
+}
+
+bool OSCClient::Initialize() {
+    WSADATA wsaData;
+    int result = WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (result != 0) {
+        return false;
+    }
+
+    SOCKET sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock == INVALID_SOCKET) {
+        WSACleanup();
+        return false;
+    }
+
+    // Allow address reuse so we can bind even if there's a lingering socket.
+    BOOL reuseAddr = TRUE;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuseAddr, sizeof(reuseAddr));
+
+    // Set receive timeout to allow graceful thread exit.
+    DWORD timeoutMs = 100;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeoutMs, sizeof(timeoutMs));
+
+    sockaddr_in serverAddr{};
+    serverAddr.sin_family = AF_INET;
+    serverAddr.sin_port = htons((u_short)m_port);
+    inet_pton(AF_INET, m_address.c_str(), &serverAddr.sin_addr);
+
+    if (bind(sock, (sockaddr*)&serverAddr, sizeof(serverAddr)) == SOCKET_ERROR) {
+        closesocket(sock);
+        WSACleanup();
+        return false;
+    }
+
+    // Increase receive buffer size.
+    int rcvbuf = 65536;
+    setsockopt(sock, SOL_SOCKET, SO_RCVBUF, (const char*)&rcvbuf, sizeof(rcvbuf));
+
+    m_socket = (void*)sock;
+    m_connected.store(true);
+    m_running.store(true);
+
+    m_receiveThread = std::thread(&OSCClient::ReceiveThread, this);
+
+    return true;
+}
+
+void OSCClient::Shutdown() {
+    m_running.store(false);
+
+    if (m_receiveThread.joinable()) {
+        m_receiveThread.join();
+    }
+
+    if (m_socket) {
+        closesocket((SOCKET)m_socket);
+        m_socket = nullptr;
+    }
+
+    m_connected.store(false);
+    WSACleanup();
+}
+
+bool OSCClient::IsConnected() const {
+    return m_connected.load();
+}
+
+bool OSCClient::HasValidGaze() const {
+    return m_hasValidLeftEye.load() || m_hasValidRightEye.load();
+}
+
+void OSCClient::SetEyeCurveExponents(float up, float down, float left, float right) {
+    m_eyeCurveExponentUp = up;
+    m_eyeCurveExponentDown = down;
+    m_eyeCurveExponentLeft = left;
+    m_eyeCurveExponentRight = right;
+}
+
+bool OSCClient::IsDataStale(uint64_t timeoutMs) const {
+    auto now = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(m_dataMutex);
+
+    bool hasLeft = m_hasValidLeftEye.load();
+    bool hasRight = m_hasValidRightEye.load();
+
+    if (!hasLeft && !hasRight) {
+        return true;
+    }
+
+    auto lastUpdate = now;
+    if (hasLeft && hasRight) {
+        lastUpdate = std::max(m_lastLeftEyeUpdate, m_lastRightEyeUpdate);
+    } else if (hasLeft) {
+        lastUpdate = m_lastLeftEyeUpdate;
+    } else {
+        lastUpdate = m_lastRightEyeUpdate;
+    }
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastUpdate).count();
+    return (uint64_t)elapsed > timeoutMs;
+}
+
+XrVector3f OSCClient::GetGazeVector() const {
+    std::lock_guard<std::mutex> lock(m_dataMutex);
+
+    bool hasLeft = m_hasValidLeftEye.load();
+    bool hasRight = m_hasValidRightEye.load();
+
+    if (!hasLeft && !hasRight) {
+        return {0.f, 0.f, -1.f}; // Default forward
+    }
+
+    if (hasLeft && hasRight) {
+        const float avgX = (m_eyeLeftX + m_eyeRightX) * 0.5f;
+        const float avgY = (m_eyeLeftY + m_eyeRightY) * 0.5f;
+        return NormalizedToUnitVector(avgX, avgY);
+    } else if (hasLeft) {
+        return NormalizedToUnitVector(m_eyeLeftX, m_eyeLeftY);
+    } else {
+        return NormalizedToUnitVector(m_eyeRightX, m_eyeRightY);
+    }
+}
+
+void OSCClient::ReceiveThread() {
+    char buffer[4096];
+
+    while (m_running.load()) {
+        sockaddr_in senderAddr{};
+        int senderAddrSize = sizeof(senderAddr);
+
+        int recvSize = recvfrom(
+            (SOCKET)m_socket, buffer, sizeof(buffer), 0, (sockaddr*)&senderAddr, &senderAddrSize);
+
+        if (!m_running.load()) {
+            break;
+        }
+
+        if (recvSize == SOCKET_ERROR) {
+            int err = WSAGetLastError();
+            if (err == WSAETIMEDOUT || err == WSAEWOULDBLOCK) {
+                continue;
+            }
+            // Socket error - disconnected.
+            m_connected.store(false);
+            break;
+        }
+
+        if (recvSize > 0) {
+            ParseOSCMessage(buffer, recvSize);
+        }
+    }
+}
+
+bool OSCClient::ParseOSCMessage(const char* buffer, int size) {
+    // OSC 1.0 message format:
+    // 1. Address Pattern (4-byte aligned null-terminated string)
+    // 2. Type Tag String (4-byte aligned, starts with ',')
+    // 3. Arguments (4-byte aligned)
+
+    if (size < 4) {
+        return false;
+    }
+
+    // Extract address pattern.
+    int addrLen = 0;
+    while (addrLen < size && buffer[addrLen] != '\0') {
+        addrLen++;
+    }
+    if (addrLen >= size) {
+        return false;
+    }
+
+    std::string address(buffer, addrLen);
+    
+    // Skip past address + null terminator + padding to 4-byte boundary.
+    int offset = addrLen + 1;
+    offset = (offset + 3) & ~3;
+
+    if (offset >= size) {
+        return false;
+    }
+
+    // Check if this is a bundle message (starts with "#bundle").
+    if (address == "#bundle") {
+        // Skip the 8-byte time tag.
+        offset += 8;
+
+        // Parse contained messages.
+        while (offset + 4 <= size) {
+            // Read the size of the contained element.
+            uint32_t elementSize;
+            memcpy(&elementSize, buffer + offset, 4);
+            // OSC uses big-endian.
+            elementSize = _byteswap_ulong(elementSize);
+            offset += 4;
+
+            if (offset + (int)elementSize > size) {
+                break;
+            }
+
+            ParseOSCMessage(buffer + offset, elementSize);
+            offset += elementSize;
+        }
+        return true;
+    }
+
+    // Check for type tag string.
+    if (buffer[offset] != ',') {
+        return false;
+    }
+
+    // Extract type tags.
+    int typeTagStart = offset + 1;
+    int typeTagLen = 0;
+    while (offset + typeTagLen < size && buffer[typeTagStart + typeTagLen] != '\0') {
+        typeTagLen++;
+    }
+
+    std::string typeTags(buffer + typeTagStart, typeTagLen);
+
+    // Skip past type tags + null terminator + padding to 4-byte boundary.
+    offset = typeTagStart + typeTagLen + 1;
+    offset = (offset + 3) & ~3;
+
+    // Handle /tracking/eye/LeftRightPitchYaw (Vector4: leftPitch, leftYaw, rightPitch, rightYaw).
+    if (address == "/tracking/eye/LeftRightPitchYaw" && offset + 16 <= size) {
+        float values[4];
+        for (int i = 0; i < 4; i++) {
+            uint32_t intVal;
+            memcpy(&intVal, buffer + offset + i * 4, 4);
+            intVal = _byteswap_ulong(intVal);
+            memcpy(&values[i], &intVal, 4);
+        }
+        HandleLeftRightPitchYaw(values[0], values[1], values[2], values[3]);
+        return true;
+    }
+
+    return true;
+}
+
+void OSCClient::HandleLeftRightPitchYaw(float leftPitch, float leftYaw, float rightPitch, float rightYaw) {
+    if (!m_loggedFirstData.exchange(true)) {
+        openxr_api_layer::log::Log("OSC: Received first valid eye data via LeftRightPitchYaw\n");
+    }
+
+    auto now = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(m_dataMutex);
+
+    // Convert pitch/yaw angles (radians) back to normalized [-1, 1] coordinates.
+    // VRCFT sends atan()-based angles; tan() recovers the original normalized values,
+    // allowing the existing NormalizedToUnitVector to work unchanged.
+    m_eyeLeftY = std::tan(-leftPitch / 180 * (float)M_PI);
+    m_eyeLeftX = std::tan(leftYaw / 180 * (float)M_PI);
+    m_eyeRightY = std::tan(-rightPitch / 180 * (float)M_PI);
+    m_eyeRightX = std::tan(rightYaw / 180 * (float)M_PI);
+
+    // Apply per-direction response curve exponents.
+    if (m_eyeLeftY > .0f) {
+        m_eyeLeftY = std::pow(m_eyeLeftY, m_eyeCurveExponentUp);
+    } else {
+        m_eyeLeftY = -std::pow(-m_eyeLeftY, m_eyeCurveExponentDown);
+    }
+    if (m_eyeRightY > .0f) {
+        m_eyeRightY = std::pow(m_eyeRightY, m_eyeCurveExponentUp);
+    } else {
+        m_eyeRightY = -std::pow(-m_eyeRightY, m_eyeCurveExponentDown);
+    }
+    if (m_eyeLeftX > .0f) {
+        m_eyeLeftX = std::pow(m_eyeLeftX, m_eyeCurveExponentRight);
+    } else {
+        m_eyeLeftX = -std::pow(-m_eyeLeftX, m_eyeCurveExponentLeft);
+    }
+    if (m_eyeRightX > .0f) {
+        m_eyeRightX = std::pow(m_eyeRightX, m_eyeCurveExponentRight);
+    } else {
+        m_eyeRightX = -std::pow(-m_eyeRightX, m_eyeCurveExponentLeft);
+    }
+
+    m_lastLeftEyeUpdate = now;
+    m_lastRightEyeUpdate = now;
+    m_hasValidLeftEye.store(true);
+    m_hasValidRightEye.store(true);
+}
+
+XrVector3f OSCClient::NormalizedToUnitVector(float x, float y) {
+    // Input: x, y in range [-1.0, 1.0]
+    // These represent gaze direction on a normalized plane.
+    // Convert to angles using atan to map uniformly across the field of view.
+    const float angleX = std::atan(x); // Horizontal angle (yaw)
+    const float angleY = std::atan(y); // Vertical angle (pitch)
+
+    // Convert spherical to Cartesian coordinates on unit sphere.
+    // OpenXR convention: x = right, y = up, z = backward.
+    const float cosY = std::cos(angleY);
+    XrVector3f result;
+    result.x = std::sin(angleX) * cosY;
+    result.y = std::sin(angleY);
+    result.z = -std::cos(angleX) * cosY; // Negative because +z is backward
+
+    // Normalize to ensure unit length.
+    const float len = std::sqrt(result.x * result.x + result.y * result.y + result.z * result.z);
+    if (len > 0.0001f) {
+        result.x /= len;
+        result.y /= len;
+        result.z /= len;
+    }
+
+    return result;
+}

--- a/openxr-api-layer/utils/osc_client.h
+++ b/openxr-api-layer/utils/osc_client.h
@@ -1,0 +1,87 @@
+// MIT License
+//
+// Copyright(c) 2022-2023 Matthieu Bucchianeri
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this softwareand associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and /or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright noticeand this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <string>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <chrono>
+
+// OpenXR types for gaze vector output.
+#include <openxr/openxr.h>
+
+struct SOCKET__; // Forward declare to avoid pulling winsock2 into the header.
+typedef SOCKET__* SOCKET_T;
+#define OSC_INVALID_SOCKET ((SOCKET_T)-1)
+
+class OSCClient {
+  public:
+    OSCClient(const char* address, int port);
+    ~OSCClient();
+
+    bool Initialize();
+    void Shutdown();
+    bool IsConnected() const;
+    bool HasValidGaze() const;
+    XrVector3f GetGazeVector() const;
+    bool IsDataStale(uint64_t timeoutMs) const;
+
+    // Set the curve exponents per direction.
+    // Each: default 1 = linear, >1 = gentle at center/fierce at edge, <1 = fierce at center/gentle at edge
+    void SetEyeCurveExponents(float up, float down, float left, float right);
+
+    // Thread function for background receive.
+    void ReceiveThread();
+
+  private:
+    std::string m_address;
+    int m_port;
+    void* m_socket; // SOCKET stored as void* to avoid winsock2 header dependency
+    std::thread m_receiveThread;
+    std::atomic<bool> m_running{false};
+    std::atomic<bool> m_connected{false};
+
+    // Thread-safe eye data (VRCFT Unified Expressions format).
+    mutable std::mutex m_dataMutex;
+    float m_eyeLeftX{0.f};  // -1.0 (left) to +1.0 (right)
+    float m_eyeLeftY{0.f};  // -1.0 (down) to +1.0 (up)
+    float m_eyeRightX{0.f}; // -1.0 (left) to +1.0 (right)
+    float m_eyeRightY{0.f}; // -1.0 (down) to +1.0 (up)
+    std::atomic<bool> m_hasValidLeftEye{false};
+    std::atomic<bool> m_hasValidRightEye{false};
+    std::atomic<bool> m_loggedFirstData{false};
+    float m_eyeCurveExponentUp{1.0f};
+    float m_eyeCurveExponentDown{1.0f};
+    float m_eyeCurveExponentLeft{1.0f};
+    float m_eyeCurveExponentRight{1.0f};
+    std::chrono::time_point<std::chrono::steady_clock> m_lastLeftEyeUpdate{};
+    std::chrono::time_point<std::chrono::steady_clock> m_lastRightEyeUpdate{};
+
+    // OSC parsing.
+    bool ParseOSCMessage(const char* buffer, int size);
+    void HandleLeftRightPitchYaw(float leftPitch, float leftYaw, float rightPitch, float rightYaw);
+
+    // Convert 2D normalized coordinates to 3D unit vector.
+    static XrVector3f NormalizedToUnitVector(float x, float y);
+};

--- a/settings.cfg
+++ b/settings.cfg
@@ -14,6 +14,21 @@ turbo_mode=0
 horizontal_fixed_section=0.5
 vertical_fixed_section=0.45
 
+# VRCFT OSC Server Eye Tracking
+# Enable eye tracking from VRCFT OSC server
+osc_tracking_enabled=0
+# OSC server address
+osc_address=127.0.0.1
+# OSC server port
+osc_port=9000
+# Data timeout in milliseconds (treat as stale if no data received)
+osc_timeout_ms=500
+# Exponent (Curve) factor per direction (default 1 = linear, >1 = gentle at center/fierce at edge, <1 = fierce at center/gentle at edge)
+osc_eye_curve_exponent_up=1.0
+osc_eye_curve_exponent_down=1.0
+osc_eye_curve_exponent_left=1.0
+osc_eye_curve_exponent_right=1.0
+
 [Oculus]
 peripheral_multiplier=0.4
 focus_multiplier=1.1


### PR DESCRIPTION
* Add VRCFT OSC support

Add an option to use gaze data from VRCFT. This would enable eye tracking solutions that supplies gaze data through OSC instead of OpenXR runtime to be used for foveated rendering, including Quest 3 + ETVR, Pico 4 Pro/Enterprise, and possibly other 3rd party eye tracking solutions. As their gaze mapping might not be very accurate, the curve parameters are added so at least it could be tuned.

I've tested it on Pico 4 Pro. Other tracking solutions should be functioning as long as it supplies full gaze data to the VRCFT plugin.